### PR TITLE
build(ci): Update uv workflow to set `--locked` in `uv sync` only on master branch

### DIFF
--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -25,5 +25,15 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Set environment for branch
+        run: |
+          if [[ $GITHUB_REF_NAME == 'master' ]]; then
+              echo "UV_LOCKED=1" >> "$GITHUB_ENV"
+          fi
+
+      - name: Verify set environment variable
+        run: |
+          echo $UV_LOCKED
+
       - name: Install the project
         run: uv sync --locked --all-extras --dev


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow with improved environment configuration and verification steps for better deployment consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->